### PR TITLE
Windows package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Vagrant Cookbook Changelog
 
+## 0.7.2
+
+* The package extension for the vagrant mac package changed. 
+  After version 1.9.2 the extension is _x86_64.dmg.
+* The package extension for the vagrant windows package changed. 
+  After version 1.9.5 the extension is <machinetype>.msi.
+
 ## 0.7.1
 
 * Fixes for Chef 13 compat

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -78,7 +78,7 @@ module Vagrant
     end
 
     def windows_machine
-      node['kernel']['machine'] == 'x86_64' ? '_x86_64' : '_i686' 
+      node['kernel']['machine'] == 'x86_64' ? '_x86_64' : '_i686'
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -48,7 +48,7 @@ module Vagrant
     def package_extension
       extension = value_for_platform_family(
         'mac_os_x' =>  mac_os_x_extension,
-        'windows' => '.msi',
+        'windows' => windows_extension,
         'debian' => '_x86_64.deb',
         %w(rhel suse fedora) => '_x86_64.rpm'
       )
@@ -63,12 +63,22 @@ module Vagrant
     end
 
     def extract_checksum(sha256sums)
+      raise "SHA 256 sum not found for the Vagrant package #{package_name}" unless sha256sums.grep(/#{package_name}/)[0].respond_to?(:split)
       sha256sums.grep(/#{package_name}/)[0].split.first
     end
 
     def mac_os_x_extension
       last_using_dmg = Gem::Version.new('1.9.2')
       Gem::Version.new(package_version) > last_using_dmg ? '_x86_64.dmg' : '.dmg'
+    end
+
+    def windows_extension
+      last_using_msi = Gem::Version.new('1.9.5')
+      Gem::Version.new(package_version) > last_using_msi ? "#{windows_machine}.msi" : '.msi'
+    end
+
+    def windows_machine
+      node['kernel']['machine'] == 'x86_64' ? '_x86_64' : '_i686' 
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ maintainer_email 'cookbooks@housepub.org'
 license          'Apache-2.0'
 description      'Installs Vagrant and provides a vagrant_plugin LWRP for installing Vagrant plugins.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.7.1'
+version          '0.7.2'
 
 source_url 'https://github.com/jtimberman/vagrant-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/jtimberman/vagrant-cookbook/issues' if respond_to?(:issues_url)

--- a/spec/unit/recipes/windows_spec.rb
+++ b/spec/unit/recipes/windows_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'vagrant::windows' do
 
     it "installs Vagrant version #{VAGRANT_DEFAULT_VERSION}" do
       expect(windows_node).to install_windows_package('Vagrant').with(
-        source: "https://releases.hashicorp.com/vagrant/#{VAGRANT_DEFAULT_VERSION}/vagrant_#{VAGRANT_DEFAULT_VERSION}.msi",
+        source: "https://releases.hashicorp.com/vagrant/#{VAGRANT_DEFAULT_VERSION}/vagrant_#{VAGRANT_DEFAULT_VERSION}_x86_64.msi",
         version: VAGRANT_DEFAULT_VERSION
       )
     end
@@ -41,7 +41,7 @@ RSpec.describe 'vagrant::windows' do
     cached(:windows_node) do
       ChefSpec::SoloRunner.new(
         platform: 'windows',
-        version: '2012R2'
+        version:  '2012R2'
       ) do |node|
         node.normal['vagrant']['version'] = VAGRANT_OVERRIDE_VERSION
         node.normal['vagrant']['msi_version'] = VAGRANT_OVERRIDE_VERSION
@@ -50,8 +50,27 @@ RSpec.describe 'vagrant::windows' do
 
     it "installs Vagrant version #{VAGRANT_OVERRIDE_VERSION}" do
       expect(windows_node).to install_windows_package('Vagrant').with(
-        source: "https://releases.hashicorp.com/vagrant/#{VAGRANT_OVERRIDE_VERSION}/vagrant_#{VAGRANT_OVERRIDE_VERSION}.msi",
+        source: "https://releases.hashicorp.com/vagrant/#{VAGRANT_OVERRIDE_VERSION}/vagrant_#{VAGRANT_OVERRIDE_VERSION}_x86_64.msi",
         version: VAGRANT_OVERRIDE_VERSION
+      )
+    end
+  end
+
+  context 'when you override with an old the version' do
+    cached(:windows_node) do
+      ChefSpec::SoloRunner.new(
+        platform: 'windows',
+        version: '2012R2'
+      ) do |node|
+        node.normal['vagrant']['version'] = '1.9.1'
+        node.normal['vagrant']['msi_version'] = '1.9.1'
+      end.converge(described_recipe)
+    end
+
+    it "installs Vagrant version 1.9.1" do
+      expect(windows_node).to install_windows_package('Vagrant').with(
+        source: "https://releases.hashicorp.com/vagrant/1.9.1/vagrant_1.9.1.msi",
+        version: '1.9.1'
       )
     end
   end

--- a/spec/unit/recipes/windows_spec.rb
+++ b/spec/unit/recipes/windows_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe 'vagrant::windows' do
       end.converge(described_recipe)
     end
 
-    it "installs Vagrant version 1.9.1" do
+    it 'installs Vagrant version 1.9.1' do
       expect(windows_node).to install_windows_package('Vagrant').with(
-        source: "https://releases.hashicorp.com/vagrant/1.9.1/vagrant_1.9.1.msi",
+        source: 'https://releases.hashicorp.com/vagrant/1.9.1/vagrant_1.9.1.msi',
         version: '1.9.1'
       )
     end


### PR DESCRIPTION
The vagrant windows package name was changed to include the machine architecture in version 1.9.5.  This change should generate the correct package names.