### PR TITLE
Fix win2012r2 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,7 +4,15 @@ driver:
 
 provisioner:
   name: chef_zero
-
+  # Codes that Windows might use to say it's rebooting.
+  # We need the retry logic or chef will see the reboot
+  # as a complete failure and give up.
+  retry_on_exit_code: [35, 259]
+  max_retries: 3
+  wait_for_retry: 180
+  client_rb:
+    exit_status: :enabled
+    client_fork: false
 verifier:
   name: inspec
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 
 return unless %w(darwin windows linux).include?(node['os'])
 
-default['vagrant']['version']     = '1.9.7'
+default['vagrant']['version']     = '2.0.3'
 default['vagrant']['msi_version'] = nil
 
 # the URL and checksum are calculated from the package version by helper methods

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -71,10 +71,7 @@ module Vagrant
 
     def execute_cli(command)
       shell_out!(
-        command,
-        user: username,
-        password: password, # required on Windows
-        env: { 'VAGRANT_HOME' => vagrant_home }
+        command
       )
     end
 

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -14,7 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-use_inline_resources if defined?(:use_inline_resources)
+use_inline_resources if defined?(:use_inline_resources) # ~FC113
 
 # Support whyrun
 def whyrun_supported?

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -24,4 +24,13 @@ windows_package 'Vagrant' do
   version vagrant_version
   source vagrant_url
   checksum vagrant_checksum
+  returns [1641, 3010]
+  options '/norestart'
+  # We'll do the restart through chef itself to prevent the cookbook from
+  # continuing to run while the Vagrant MSI is telling Windows to reboot
+  notifies :reboot_now, 'reboot[reboot_now]', :immediately
+end
+
+reboot 'reboot_now' do
+  action :nothing
 end

--- a/spec/unit/recipes/windows_spec.rb
+++ b/spec/unit/recipes/windows_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'vagrant::windows' do
   include_context 'mock vagrant_sha256sum'
 
   context 'with default attributes' do
-    VAGRANT_DEFAULT_VERSION = '1.9.7'.freeze
+    VAGRANT_DEFAULT_VERSION = '2.0.3'.freeze
 
     cached(:windows_node) do
       ChefSpec::SoloRunner.new(

--- a/test/integration/default_chef12/inspec/vagrant_spec.rb
+++ b/test/integration/default_chef12/inspec/vagrant_spec.rb
@@ -1,5 +1,5 @@
 describe command('vagrant --version') do
-  its('stdout') { should match(/Vagrant 1.9.7/) }
+  its('stdout') { should match(/Vagrant 2.0.3/) }
   its('stderr') { should eq '' }
 end
 

--- a/test/integration/default_chef13/inspec/vagrant_spec.rb
+++ b/test/integration/default_chef13/inspec/vagrant_spec.rb
@@ -1,5 +1,5 @@
 describe command('vagrant --version') do
-  its('stdout') { should match(/Vagrant 1.9.7/) }
+  its('stdout') { should match(/Vagrant 2.0.3/) }
   its('stderr') { should eq '' }
 end
 


### PR DESCRIPTION
Fixes for Windows 2012R2:

* The Vagrant installer needs to reboot windows, but the MSI does this in a way that chef can't handle. As an alternative, we make chef interrupt itself and reboot the instance.
* Related to the above, the MSI returns two specific exit codes when it finishes (but not `0`...) that chef needs to know about.
* Vagrant version 1.9.7 suffers from the issue described in #82 (`Expected process to exit with [0], but received '-1073741515'`). For unknown reasons, this problem is resolved by using 2.0.3 (Perhaps also earlier versions, but they were not tested.)
* Elevating privileges (in `execute_cli()`) would be the logical thing to do -- it makes sense. For some reason, this leads Windows to complain that the vagrant user doesn't have two specific NT rights. Adding those rights does not resolve the complaint. Dropping the request to elevate privileges _does_ seem to resolve it.
* It's hard to tell exactly what's going on, but the environment variable `VAGRANT_HOME` appears to confuse Vagrant into installing plugins into locations where Vagrant doesn't see them (`vagrant plugin list`). Dropping this environment variable resolves the issue.

Resolves #81 and #82